### PR TITLE
fix to publish gh-page as project

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,9 @@ email: nukosuke@lavabit.com
 description: >-
   lifenode is simple theme for Jekyll.
 
+# URL settings
+permalink: "/:year/:month/:day/:title:output_ext"
+
 # build settings
 markdown: kramdown
 theme: lifenode

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <div class="post">
-  <a href="/" title="Home">&laquo;&nbsp;Home</a>
+  <a href="{{ '/' | relative_url }}" title="Home">&laquo;&nbsp;Home</a>
   <h1 class="ln-post-title">{{ page.title }}</h1>
   <div class="ln-slash-stripe"></div>
   {{ content }}


### PR DESCRIPTION
Home link was not working.
use `relative_url` instead of absolute path.

and remove `:category` from permalink.